### PR TITLE
Support other libraries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     rev: v1.1.1
     hooks:
       - id: mypy
+        args: [--disable-error-code=name-defined, --disable-error-code=import]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1

--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from typing import Any
 
 import aiohttp
-import discord
-from discord.ext import bridge, commands
+from discord.ext import commands
 
 from .emb import error as error_emb
 from .enums import CogLog, HelpStyle, ReadyEvent
+from .internal.dc import CogMeta, bridge, discord
 from .logs import DEFAULT_LOG, custom_log, set_log
 from .times import dc_timestamp
 
@@ -27,7 +27,13 @@ from .internal import (  # isort: skip
 )
 
 
-class Bot(discord.Bot):
+try:
+    _main_bot = discord.Bot
+except AttributeError:
+    _main_bot = commands.Bot
+
+
+class Bot(_main_bot):  # type: ignore
     """The EzCord bot class. This is a subclass of :class:`discord.Bot`.
 
     .. hint::
@@ -502,10 +508,10 @@ class BridgeBot(Bot, bridge.Bot):
         super().__init__(*args, **kwargs)
 
 
-class _CogMeta(discord.cog.CogMeta):
+class _CogMeta(CogMeta):
     """A metaclass for cogs that adds an ``emoji`` attribute."""
 
-    def __new__(cls, *args, **kwargs) -> discord.cog.CogMeta:
+    def __new__(cls, *args, **kwargs) -> CogMeta:
         name, bases, attrs = args
         attrs["emoji"] = kwargs.pop("emoji", None)
         attrs["group"] = kwargs.pop("group", None)

--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -29,7 +29,7 @@ from .internal import (  # isort: skip
 
 
 try:
-    _main_bot = discord.Bot
+    _main_bot = discord.Bot  # Pycord
 except AttributeError:
     _main_bot = commands.Bot
 
@@ -494,7 +494,7 @@ class Bot(_main_bot):  # type: ignore
         self,
         token: str | None = None,
         env_path: str | os.PathLike[str] = ".env",
-        var_name: str = "TOKEN",
+        token_var: str = "TOKEN",
         **kwargs: Any,
     ) -> None:
         """This overrides the default :meth:`discord.Bot.run` method and automatically loads the token.
@@ -505,13 +505,13 @@ class Bot(_main_bot):  # type: ignore
             The bot token. If this is ``None``, the token will be loaded from the environment.
         env_path:
             The path to the environment file. Defaults to ``.env``.
-        var_name:
+        token_var:
             The name of the token variable in the environment file. Defaults to ``TOKEN``.
         **kwargs:
             Additional keyword arguments for :meth:`discord.Bot.run`.
         """
         load_dotenv(env_path)
-        env_token = os.getenv("TOKEN")
+        env_token = os.getenv(token_var)
         if env_token is not None:
             token = env_token
 

--- a/ezcord/cogs/help.py
+++ b/ezcord/cogs/help.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import random
 
-import discord
-from discord.commands import slash_command
-
 from .. import emb
 from ..bot import Bot, Cog
 from ..components import View
 from ..enums import HelpStyle
 from ..internal import replace_embed_values, t
+from ..internal.dc import discord, slash_command
 from ..logs import log
 
 

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -23,9 +23,9 @@ import os
 from typing import Callable
 
 import aiohttp
-import discord
 
 from .internal import get_error_text
+from .internal.dc import discord
 from .logs import log
 
 _view_error_handlers: list[Callable] = []

--- a/ezcord/emb.py
+++ b/ezcord/emb.py
@@ -18,9 +18,8 @@ from __future__ import annotations
 
 import copy
 
-import discord
-
 from .internal import copy_kwargs, load_embed, replace_dict, save_embeds
+from .internal.dc import discord
 from .logs import log
 
 

--- a/ezcord/internal/dc/__init__.py
+++ b/ezcord/internal/dc/__init__.py
@@ -1,0 +1,13 @@
+from .dc_imports import discord
+
+try:
+    # py-cord
+    from discord.cog import CogMeta
+    from discord.commands import slash_command
+    from discord.ext import bridge
+except ImportError:
+    # discord.py
+    from discord.ext.commands import CogMeta
+
+    slash_command = __import__("discord.app_commands", fromlist=[""])
+    bridge = __import__("discord.ext.commands", fromlist=[""])

--- a/ezcord/internal/dc/dc_imports.py
+++ b/ezcord/internal/dc/dc_imports.py
@@ -1,0 +1,7 @@
+libs = ["discord", "nextcord", "disnake"]
+for lib in libs:
+    try:
+        discord = __import__(lib)
+        break
+    except ImportError:
+        continue

--- a/ezcord/internal/embed_templates.py
+++ b/ezcord/internal/embed_templates.py
@@ -7,18 +7,17 @@ from copy import deepcopy
 from functools import cache
 from pathlib import Path
 
-import discord
-from discord import Color, Embed
+from ..internal.dc import discord
 
-_TEMPLATES: dict[str, Embed] = {
-    "success_embed": Embed(color=Color.green()),
-    "error_embed": Embed(color=Color.red()),
-    "warn_embed": Embed(color=Color.gold()),
-    "info_embed": Embed(color=Color.blue()),
+_TEMPLATES: dict[str, discord.Embed] = {
+    "success_embed": discord.Embed(color=discord.Color.green()),
+    "error_embed": discord.Embed(color=discord.Color.red()),
+    "warn_embed": discord.Embed(color=discord.Color.gold()),
+    "info_embed": discord.Embed(color=discord.Color.blue()),
 }
 
 
-def save_embeds(**kwargs: Embed | str):
+def save_embeds(**kwargs: discord.Embed | str):
     """Save multiple embeds to a JSON file.
 
     If one of the default values is not included, a default template will be saved.
@@ -40,7 +39,7 @@ def save_embeds(**kwargs: Embed | str):
 
 
 @cache
-def load_embed(name: str) -> Embed | str:
+def load_embed(name: str) -> discord.Embed | str:
     """Load an embed template from a JSON file."""
     parent = Path(__file__).parent.absolute()
     json_path = parent.joinpath("embeds.json")
@@ -54,7 +53,7 @@ def load_embed(name: str) -> Embed | str:
         return embeds[name]
 
     try:
-        return Embed.from_dict(embeds[name])
+        return discord.Embed.from_dict(embeds[name])
     except KeyError:
         if name in _TEMPLATES.keys():
             save_embeds()

--- a/ezcord/internal/ready_style.py
+++ b/ezcord/internal/ready_style.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from collections import OrderedDict
 from itertools import cycle, islice
 
-import discord
 from colorama import Fore
 
 from .. import __version__
 from ..enums import ReadyEvent
+from ..internal.dc import discord
 from ..logs import log
 from .colors import get_escape_code
 

--- a/ezcord/internal/ready_style.py
+++ b/ezcord/internal/ready_style.py
@@ -36,15 +36,20 @@ READY_TITLE: str = f"Bot is online with EzCord {__version__}"
 DEFAULT_COLORS: list[str] = [Fore.CYAN, Fore.MAGENTA, Fore.YELLOW, Fore.GREEN, Fore.BLUE, Fore.RED]
 
 
-def get_default_info(bot: discord.Bot) -> list[tuple[str, str]]:
-    cmds = [
-        cmd for cmd in bot.walk_application_commands() if type(cmd) != discord.SlashCommandGroup
-    ]
+def get_default_info(bot: discord.ext.commands.Bot) -> list[tuple[str, str]]:
+    try:
+        lib_name = "Pycord"
+        cmds = [
+            cmd for cmd in bot.walk_application_commands() if type(cmd) != discord.SlashCommandGroup
+        ]
+    except AttributeError:
+        lib_name = "Version"
+        cmds = bot.commands  # prevents errors with other libs
 
     return [
         ("Bot", f"{bot.user}"),
         ("ID", f"{bot.user.id}"),
-        ("Pycord", discord.__version__),
+        (lib_name, discord.__version__),
         ("Commands", f"{len(cmds):,}"),
         ("Guilds", f"{len(bot.guilds):,}"),
         ("Latency", f"{round(bot.latency * 1000):,}ms"),

--- a/ezcord/logs.py
+++ b/ezcord/logs.py
@@ -10,10 +10,10 @@ import sys
 from typing import Literal
 
 import aiohttp
-import discord
 from colorama import Fore
 
 from .enums import LogFormat, TimeFormat
+from .internal.dc import discord
 
 from .internal.colors import (  # isort: skip
     DEFAULT_COLOR,

--- a/ezcord/utils.py
+++ b/ezcord/utils.py
@@ -3,7 +3,7 @@
 import io
 import json
 
-import discord
+from .internal.dc import discord
 
 
 def create_json_file(


### PR DESCRIPTION
This PR allows EzCord to be used with libraries such as discord.py. While `ezcord.Bot` should work with other libs, some other features may not work, as Pycord will stay the only fully supported library.