### PR TITLE
fix: improve usage without Discord

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Test Ezcord without Discord libraries
         run: |
-          pytest -k "not test_libs"
+          pytest -m "not dc"
 
       - name: Test Pycord
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,10 @@ jobs:
           pip install pytest
           pip install pytest-asyncio
 
+      - name: Test Ezcord without Discord libraries
+        run: |
+          pytest -k "test_libs"
+
       - name: Test Pycord
         run: |
           pip install git+https://github.com/Pycord-Development/pycord

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Test Pycord
         run: |
-          pip install git+https://github.com/Pycord-Development/pycord
+          pip install py-cord
           pytest
 
       - name: Test Discord.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Test Ezcord without Discord libraries
         run: |
-          pytest -k "test_libs"
+          pytest -k "not test_libs"
 
       - name: Test Pycord
         run: |

--- a/ezcord/internal/dc/__init__.py
+++ b/ezcord/internal/dc/__init__.py
@@ -10,7 +10,16 @@ class FakeDiscord:
     CogMeta = type
 
     def __getattr__(self, name):
-        if name in ("Embed", "View", "Modal", "ApplicationContext", "Interaction", "Bot", "Cog"):
+        if name in (
+            "Embed",
+            "View",
+            "Modal",
+            "ApplicationContext",
+            "Interaction",
+            "Bot",
+            "Cog",
+            "AutoShardedBot",
+        ):
             return NoDiscordLibFound
 
         return FakeDiscord()

--- a/ezcord/internal/dc/__init__.py
+++ b/ezcord/internal/dc/__init__.py
@@ -11,14 +11,14 @@ class FakeDiscord:
 
     def __getattr__(self, name):
         if name in (
-            "Embed",
-            "View",
-            "Modal",
             "ApplicationContext",
-            "Interaction",
+            "AutoShardedBot",
             "Bot",
             "Cog",
-            "AutoShardedBot",
+            "Embed",
+            "Interaction",
+            "Modal",
+            "View",
         ):
             return NoDiscordLibFound
 

--- a/ezcord/times.py
+++ b/ezcord/times.py
@@ -101,7 +101,7 @@ def convert_dt(
             dt = dt.astimezone()
 
         return convert_time(
-            abs((dt - discord.utils.utcnow()).total_seconds()), relative, use_locale=use_locale
+            abs((dt - datetime.now(timezone.utc)).total_seconds()), relative, use_locale=use_locale
         )
 
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -34,6 +34,7 @@ class UserDB(ezcord.DBHandler):
         return await self.one("SELECT coins FROM users WHERE user_id = ?", (user_id,))
 
 
+@pytest.mark.dc
 def test_libs():
     """Test compatibility with different Discord libraries."""
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -52,7 +52,6 @@ async def test_db():
 
     with tempfile.NamedTemporaryFile(delete=False) as db_file:
         db = UserDB(db_file.name)
-        print(db_file.name)
 
         await db.setup()
         await db.add_coins(12345, 100)

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -10,7 +10,6 @@ def test_convert_time():
     assert isinstance(ezcord.convert_time(5), str)
 
 
-@pytest.mark.dc
 def test_convert_dt():
     dt = datetime.now(tz=timezone.utc)
 

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -7,11 +7,15 @@ from ezcord import ConvertTimeError
 
 
 def test_convert_time():
+    assert isinstance(ezcord.convert_time(5), str)
+
+
+@pytest.mark.dc
+def test_convert_dt():
     dt = datetime.now(tz=timezone.utc)
 
     assert isinstance(ezcord.convert_dt(dt), str)
     assert isinstance(ezcord.convert_dt(timedelta(seconds=5)), str)
-    assert isinstance(ezcord.convert_time(5), str)
 
 
 @pytest.mark.dc

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -14,6 +14,7 @@ def test_convert_time():
     assert isinstance(ezcord.convert_time(5), str)
 
 
+@pytest.mark.dc
 def test_dc_timestamp():
     result = ezcord.dc_timestamp(0)
     assert result.startswith("<t:") and result.endswith(":R>")


### PR DESCRIPTION
This PR fixes the usage without a supported Discord library.
- Added tests for that case
- Added test markers to mark all tests that require a Discord library
- Allow `convert_time` usage without Discord
- Renamed main test file to `test_general.py`