### PR TITLE
feat: add functionality for default components

### DIFF
--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -1,19 +1,9 @@
 """Classes that are adding some functionality for default components.
 
-.. note::
+.. hint::
 
-        If you want to register global checks and error handlers, all Views must
-        inherit from :class:`~EzView` instead of :class:`discord.ui.View`.
-
-        .. code-block:: python
-
-            from ezcord import View
-
-            class MyView(View):  # right
-                ...
-
-            class MyView(discord.ui.View):  # wrong
-                ...
+        Components in your code are automatically replaced with the ones from this module.
+        You don't need to change any code.
 """
 
 from __future__ import annotations
@@ -208,5 +198,10 @@ class Modal(discord.ui.Modal):
             await error_coro(error, interaction)
 
 
+# aliases
 EzModal = Modal
 EzView = View
+
+# enable error handling for default components
+discord.ui.View = View
+discord.ui.Modal = Modal

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -3,7 +3,7 @@
 .. hint::
 
         Components in your code are automatically replaced with the ones from this module.
-        You don't need to change any code.
+        You can use `discord.ui.View` instead of `ezcord.View`.
 """
 
 from __future__ import annotations

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -19,6 +19,7 @@ from .errors import ErrorMessageSent
 from .internal import get_error_text
 from .internal.dc import PYCORD, discord
 from .logs import log
+from .utils import warn_deprecated
 
 _view_error_handlers: list[Callable] = []
 _view_checks: list[Callable] = []
@@ -198,10 +199,20 @@ class Modal(discord.ui.Modal):
             await error_coro(error, interaction)
 
 
-# aliases
-EzModal = Modal
-EzView = View
+class EzView(View):
+    """Alias for :class:`View`."""
 
-# enable error handling for default components
+    def __init_subclass__(cls, **kwargs):
+        warn_deprecated("ezcord.EzView", "discord.ui.View", "2.6")
+
+
+class EzModal(Modal):
+    """Alias for :class:`Modal`."""
+
+    def __init_subclass__(cls, **kwargs):
+        warn_deprecated("ezcord.EzModal", "discord.ui.Modal", "2.6")
+
+
+# replace all default components with Ezcord components
 discord.ui.View = View
 discord.ui.Modal = Modal

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -26,7 +26,7 @@ _view_checks: list[Callable] = []
 _view_check_failures: list[Callable] = []
 _modal_error_handlers: list[Callable] = []
 
-__all__ = ("event", "Modal", "View")
+__all__ = ("event", "Modal", "View", "EzView", "EzModal")
 
 
 def _check_coro(func):

--- a/ezcord/utils.py
+++ b/ezcord/utils.py
@@ -27,6 +27,7 @@ __all__ = (
     "ez_autocomplete",
     "count_lines",
     "load_message",
+    "warn_deprecated",
 )
 
 

--- a/ezcord/utils.py
+++ b/ezcord/utils.py
@@ -10,6 +10,7 @@ import json
 import os
 import random
 import re
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -282,3 +283,46 @@ async def load_message(
         return None
 
     return message
+
+
+def warn_deprecated(
+    name: str,
+    instead: str | None = None,
+    since: str | None = None,
+    removed: str | None = None,
+    reference: str | None = None,
+    stacklevel: int = 3,
+) -> None:
+    """Warn about a deprecated function, with the ability to specify details about the deprecation. Emits a
+    DeprecationWarning.
+
+    Parameters
+    ----------
+    name: str
+        The name of the deprecated function.
+    instead:
+        A recommended alternative to the function.
+    since:
+        The version in which the function was deprecated.
+    removed:
+        The version in which the function is planned to be removed.
+    reference:
+        A reference that explains the deprecation, typically a URL to a page such as a changelog entry or a GitHub
+        issue/PR.
+    stacklevel:
+        The stacklevel kwarg passed to :func:`warnings.warn`. Defaults to ``3``.
+    """
+    warnings.simplefilter("always", DeprecationWarning)
+    message = f"'{name}' is deprecated"
+    if since:
+        message += f" since version {since}"
+    if removed:
+        message += f" and will be removed in version {removed}"
+    if instead:
+        message += f", consider using '{instead}' instead"
+    message += "."
+    if reference:
+        message += f" See {reference} for more information."
+
+    warnings.warn(message, stacklevel=stacklevel, category=DeprecationWarning)
+    warnings.simplefilter("default", DeprecationWarning)


### PR DESCRIPTION
Previously, `ezcord.View` or `ezcord.Modal` had to be used to enable certain features, such as error handling. With this PR, all default components (`discord.ui.View`, `discord.ui.Modal`) have this functionality automatically.