### PR TITLE
feat: add utils.format_number

### DIFF
--- a/ezcord/utils.py
+++ b/ezcord/utils.py
@@ -298,13 +298,17 @@ async def load_message(
     return message
 
 
-def format_number(number: int) -> str:
+def format_number(number: int, *, decimal_places: int = 1, trailing_zero: bool = False) -> str:
     """Format a big number to short and readable format.
 
     Parameters
     ----------
     number:
         The number to format.
+    decimal_places:
+        The amount of decimal places to display. Defaults to ``1``.
+    trailing_zero:
+        Whether to show trailing zeros. Defaults to ``False``.
 
     Returns
     -------
@@ -315,18 +319,29 @@ def format_number(number: int) -> str:
     -------
     >>> format_number(1_000_000)
     '1M'
+    >>> format_number(1_550, decimal_places=2)
+    '1.55K'
+    >>> format_number(1_000, trailing_zero=True)
+    '1.0K'
     """
 
+    suffix = ""
     if number >= 1_000_000_000 or number <= -1_000_000_000:
-        txt = f"{number / 1_000_000_000:.1f}B"
+        txt = f"{number / 1_000_000_000:.{decimal_places}f}"
+        suffix = "B"
     elif number >= 1_000_000 or number <= -1_000_000:
-        txt = f"{number / 1_000_000:.1f}M"
+        txt = f"{number / 1_000_000:.{decimal_places}f}"
+        suffix = "M"
     elif number >= 100 or number <= -100:
-        txt = f"{number / 1_000:.1f}K"
+        txt = f"{number / 1_000:.{decimal_places}f}"
+        suffix = "K"
     else:
         txt = str(number)
 
-    return str(txt).replace(".0", "")
+    if not trailing_zero:
+        txt = txt.rstrip("0").rstrip(".")
+
+    return txt + suffix
 
 
 def warn_deprecated(

--- a/ezcord/utils.py
+++ b/ezcord/utils.py
@@ -297,6 +297,36 @@ async def load_message(
     return message
 
 
+def format_number(number: int) -> str:
+    """Format a big number to short and readable format.
+
+    Parameters
+    ----------
+    number:
+        The number to format.
+
+    Returns
+    -------
+    :class:`str`
+        The formatted number.
+
+    Example
+    -------
+    >>> format_number(1_000_000)
+    '1M'
+    """
+
+    txt = ""
+    if number >= 1_000_000_000:
+        txt = f"{number / 1_000_000_000:.1f}B"
+    elif number >= 1_000_000:
+        txt = f"{number / 1_000_000:.1f}M"
+    elif number >= 1_000:
+        txt = f"{number / 1_000:.1f}k"
+
+    return str(txt).replace(".0", "")
+
+
 def warn_deprecated(
     name: str,
     instead: str | None = None,

--- a/ezcord/utils.py
+++ b/ezcord/utils.py
@@ -27,6 +27,7 @@ __all__ = (
     "ez_autocomplete",
     "count_lines",
     "load_message",
+    "format_number",
     "warn_deprecated",
 )
 

--- a/ezcord/utils.py
+++ b/ezcord/utils.py
@@ -317,13 +317,14 @@ def format_number(number: int) -> str:
     '1M'
     """
 
-    txt = ""
-    if number >= 1_000_000_000:
+    if number >= 1_000_000_000 or number <= -1_000_000_000:
         txt = f"{number / 1_000_000_000:.1f}B"
-    elif number >= 1_000_000:
+    elif number >= 1_000_000 or number <= -1_000_000:
         txt = f"{number / 1_000_000:.1f}M"
-    elif number >= 1_000:
-        txt = f"{number / 1_000:.1f}k"
+    elif number >= 100 or number <= -100:
+        txt = f"{number / 1_000:.1f}K"
+    else:
+        txt = str(number)
 
     return str(txt).replace(".0", "")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,3 +16,10 @@ def test_big_numbers():
     assert ezcord.format_number(-1_000_000) == "-1M"
     assert ezcord.format_number(-1_100_000) == "-1.1M"
     assert ezcord.format_number(-1_000_000_000) == "-1B"
+
+    # decimals and trailing zeros
+    assert ezcord.format_number(1_550, decimal_places=2) == "1.55K"
+    assert ezcord.format_number(1_550, decimal_places=3) == "1.55K"
+    assert ezcord.format_number(1_550, decimal_places=3, trailing_zero=True) == "1.550K"
+    assert ezcord.format_number(1_000, trailing_zero=True) == "1.0K"
+    assert ezcord.format_number(1_000, decimal_places=2, trailing_zero=True) == "1.00K"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,17 @@ import ezcord
 
 
 def test_big_numbers():
-    assert ezcord.format_number(1_000) == "1k"
+    assert ezcord.format_number(1) == "1"
+    assert ezcord.format_number(100) == "0.1K"
+    assert ezcord.format_number(1_000) == "1K"
     assert ezcord.format_number(1_000_000) == "1M"
     assert ezcord.format_number(1_100_000) == "1.1M"
+    assert ezcord.format_number(1_000_000_000) == "1B"
+
+    # negative
+    assert ezcord.format_number(-1) == "-1"
+    assert ezcord.format_number(-100) == "-0.1K"
+    assert ezcord.format_number(-1_000) == "-1K"
+    assert ezcord.format_number(-1_000_000) == "-1M"
+    assert ezcord.format_number(-1_100_000) == "-1.1M"
+    assert ezcord.format_number(-1_000_000_000) == "-1B"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,7 @@
+import ezcord
+
+
+def test_big_numbers():
+    assert ezcord.format_number(1_000) == "1k"
+    assert ezcord.format_number(1_000_000) == "1M"
+    assert ezcord.format_number(1_100_000) == "1.1M"


### PR DESCRIPTION
Format a big number to a short and readable format.
- Example: `1.000.000` -> `1M`