### PR TITLE
feat: improve i18n

### DIFF
--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -11,6 +11,7 @@ from .internal.dc import PYCORD, discord
 from .logs import log
 
 MESSAGE_SEND = discord.abc.Messageable.send
+MESSAGE_REPLY = discord.Message.reply
 MESSAGE_EDIT = discord.Message.edit
 
 INTERACTION_SEND = discord.InteractionResponse.send_message
@@ -374,6 +375,7 @@ class I18N:
                 Literal[
                     "send",
                     "edit",
+                    "reply",
                     "send_message",
                     "send_modal",
                     "edit_message",
@@ -421,6 +423,8 @@ class I18N:
             setattr(discord.abc.Messageable, "send", _localize_send(MESSAGE_SEND))
         if "edit" not in disable_translations:
             setattr(discord.Message, "edit", _localize_edit(MESSAGE_EDIT))
+        if "reply" not in disable_translations:
+            setattr(discord.Message, "reply", _localize_send(MESSAGE_REPLY))
 
         if "send_message" not in disable_translations:
             setattr(discord.InteractionResponse, "send_message", _localize_send(INTERACTION_SEND))

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -631,6 +631,14 @@ class I18N:
         if key is None:
             return None
 
+        def replace_keys(m: re.Match):
+            k = m.group(1)
+            return I18N._get_text(k, locale, count, called_class, add_locations)
+
+        # check if key contains other keys
+        if "{" in key and "}" in key:
+            key = re.sub(r"{(.*?)}", replace_keys, key)
+
         string = I18N._get_text(key, locale, count, called_class, add_locations)
 
         if count:

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -222,7 +222,7 @@ def _localize_send(send_func):
             variables = {**variables, "count": count}
 
         # Check content
-        content = I18N.load_text(content, locale, count, **variables)
+        content = I18N.load_text(content, locale, **variables)
 
         kwargs = _check_embed(locale, count, variables, **kwargs)
         kwargs = _check_embeds(locale, count, variables, **kwargs)
@@ -632,6 +632,10 @@ class I18N:
             return None
 
         string = I18N._get_text(key, locale, count, called_class, add_locations)
+
+        if count:
+            variables = {**variables, "count": count}
+
         return I18N._replace_variables(string, locale, **variables)
 
     @staticmethod

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -550,7 +550,8 @@ class I18N:
         inspect_stack = inspect.stack()
 
         # Ignore the following internal sources to determine the origin method
-        methods = ["respond"] + I18N.exclude_methods
+        # "sub" is used for regex substitution when searching for keys within other keys.
+        methods = ["respond", "sub"] + I18N.exclude_methods
         files = ["i18n", "emb", "interactions"]
 
         file, method, class_ = None, None, None

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -66,7 +66,7 @@ def t(obj: LOCALE_OBJECT, key: str, count: int | None = None, **variables):
         The count for pluralization. Defaults to ``None``.
     """
     locale = I18N.get_locale(obj)
-    return I18N.load_text(key, locale, count, **{**variables, "count": count})
+    return I18N.load_text(key, locale, count, **variables)
 
 
 class TEmbed(discord.Embed):
@@ -154,6 +154,9 @@ def _check_embeds(locale: str, count: int | None, variables: dict, **kwargs):
 def _check_view(locale: str, count: int | None, variables: dict, **kwargs):
     """Load all keys inside the view from the language file."""
 
+    if "count" in variables:
+        count = variables["count"]
+
     view = kwargs.get("view")
     if view:
         class_name = view.__class__.__name__
@@ -219,8 +222,6 @@ def _localize_send(send_func):
 
         locale = I18N.get_locale(use_locale or self)
         variables, kwargs = _extract_parameters(send_func, **kwargs)
-        if count:
-            variables = {**variables, "count": count}
 
         # Check content
         content = I18N.load_text(content, locale, **variables)
@@ -251,8 +252,6 @@ def _localize_edit(edit_func):
         """
         locale = I18N.get_locale(use_locale or self)
         variables, kwargs = _extract_parameters(edit_func, **kwargs)
-        if count:
-            variables = {**variables, "count": count}
 
         # Check content (must be a kwarg)
         content = kwargs.get("content")
@@ -281,8 +280,6 @@ async def _localize_modal(
 ):
     locale = I18N.get_locale(self)
     variables, kwargs = _extract_parameters(INTERACTION_MODAL, **kwargs)
-    if count:
-        variables = {**variables, "count": count}
     modal_name = modal.__class__.__name__
 
     modal.title = I18N.load_text(modal.title, locale, count, modal_name, **variables)

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -65,7 +65,7 @@ def t(obj: LOCALE_OBJECT, key: str, count: int | None = None, **variables):
         The count for pluralization. Defaults to ``None``.
     """
     locale = I18N.get_locale(obj)
-    return I18N.load_text(key, locale, count, **variables)
+    return I18N.load_text(key, locale, count, **{**variables, "count": count})
 
 
 class TEmbed(discord.Embed):
@@ -115,7 +115,7 @@ def _check_embed(locale: str, count: int | None, variables: dict, **kwargs):
 
     if embed:
         if "count" in variables:
-            count = variables.pop("count")
+            count = variables["count"]
         new_embed_dict = I18N.load_lang_keys(
             embed.to_dict(), locale, count, add_locations, **variables
         )
@@ -140,7 +140,7 @@ def _check_embeds(locale: str, count: int | None, variables: dict, **kwargs):
             embed = I18N.load_embed(embed, locale)
 
         if "count" in variables:
-            count = variables.pop("count")
+            count = variables["count"]
         new_embed_dict = I18N.load_lang_keys(
             embed.to_dict(), locale, count, add_locations, **variables
         )
@@ -218,6 +218,8 @@ def _localize_send(send_func):
 
         locale = I18N.get_locale(use_locale or self)
         variables, kwargs = _extract_parameters(send_func, **kwargs)
+        if count:
+            variables = {**variables, "count": count}
 
         # Check content
         content = I18N.load_text(content, locale, count, **variables)
@@ -248,6 +250,8 @@ def _localize_edit(edit_func):
         """
         locale = I18N.get_locale(use_locale or self)
         variables, kwargs = _extract_parameters(edit_func, **kwargs)
+        if count:
+            variables = {**variables, "count": count}
 
         # Check content (must be a kwarg)
         content = kwargs.get("content")
@@ -276,6 +280,8 @@ async def _localize_modal(
 ):
     locale = I18N.get_locale(self)
     variables, kwargs = _extract_parameters(INTERACTION_MODAL, **kwargs)
+    if count:
+        variables = {**variables, "count": count}
     modal_name = modal.__class__.__name__
 
     modal.title = I18N.load_text(modal.title, locale, count, modal_name, **variables)

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -664,7 +664,8 @@ class I18N:
 
         def replace_keys(m: re.Match):
             k = m.group(1)
-            return I18N._get_text(k, locale, count, called_class, add_locations)
+            check_key = I18N._get_text(k, locale, count, called_class, add_locations)
+            return check_key if check_key != k else m.group()
 
         # check if key contains other keys
         if "{" in key and "}" in key:


### PR DESCRIPTION
# Enhance i18n features
Allow multiple keys to be placed in a single value, for example a message content. This is useful for emojis, other content that is not language specific, or if you simply want to use more than one key in a single value.

## Further improvements
- Allow `count` to be used as a variable (currently only possible as pluralization attribute)
- Add support for custom language settings (currently language can only be set for Discord community servers)