### PR TITLE
feat: handle Discord AutoMod errors

### DIFF
--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -489,8 +489,17 @@ class Bot(_main_bot):  # type: ignore
                 await error_emb(ctx, tr("no_user_perms", use_locale=ctx))
 
         else:
+            automod = False
             if "original" in error.__dict__ and not self.full_error_traceback:
                 original_error = error.__dict__["original"]
+
+                if isinstance(original_error, discord.HTTPException):
+                    if original_error.code == 200000:
+                        automod = True
+                        self.logger.warning(
+                            f"**/{ctx.command.qualified_name}** was blocked by AutoMod"
+                        )
+
                 error_msg = f"{original_error.__class__.__name__}: {error.__cause__}"
                 error = original_error
             else:
@@ -504,6 +513,10 @@ class Bot(_main_bot):  # type: ignore
                     # ignore invalid interaction error, probably took too long to respond
                     if e.code != 10062:
                         self.logger.error("Could not send error message to user", exc_info=e)
+
+            if automod:
+                # Don't log AutoMod errors
+                return
 
             webhook_sent = False
             if self.error_webhook_url:

--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -515,8 +515,7 @@ class Bot(_main_bot):  # type: ignore
                         self.logger.error("Could not send error message to user", exc_info=e)
 
             if automod:
-                # Don't log AutoMod errors
-                return
+                return  # Don't log AutoMod errors
 
             webhook_sent = False
             if self.error_webhook_url:

--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -496,8 +496,9 @@ class Bot(_main_bot):  # type: ignore
                 if isinstance(original_error, discord.HTTPException):
                     if original_error.code == 200000:
                         automod = True
+                        guild_id = ctx.guild.id if ctx.guild else "None"
                         self.logger.warning(
-                            f"**/{ctx.command.qualified_name}** was blocked by AutoMod"
+                            f"**/{ctx.command.qualified_name}** was blocked by AutoMod (Guild {guild_id})"
                         )
 
                 error_msg = f"{original_error.__class__.__name__}: {error.__cause__}"

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -121,7 +121,13 @@ async def _send_error_webhook(interaction, description) -> bool:
 class View(discord.ui.View):
     ignore_timeout_errors: bool = False
 
-    """This class extends from :class:`discord.ui.View` and adds some functionality."""
+    """This class extends from :class:`discord.ui.View` and adds some functionality.
+
+    Parameters
+    ----------
+    ignore_timeout_error:
+        If ``True``, views will not raise an exception if an error occurs during the timeout event.
+    """
 
     def __init__(self, *args, ignore_timeout_error: bool = False, **kwargs):
         self.ignore_timeout_error = ignore_timeout_error

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -139,7 +139,10 @@ class View(discord.ui.View):
 
         if isinstance(error, discord.HTTPException):
             if error.code == 200000:
-                log.warning(f"View **{type(self).__name__}** was blocked by AutoMod")
+                guild_id = interaction.guild.id if interaction.guild else "None"
+                log.warning(
+                    f"View **{type(self).__name__}** was blocked by AutoMod (Guild {guild_id})"
+                )
                 return
 
         description = get_error_text(interaction, error, item)

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -137,11 +137,15 @@ class View(discord.ui.View):
         if type(error) is ErrorMessageSent:
             return
 
+        view_name = type(self).__name__
+        view_module = type(self).__module__
+
         if isinstance(error, discord.HTTPException):
             if error.code == 200000:
                 guild_id = interaction.guild.id if interaction.guild else "None"
                 log.warning(
-                    f"View **{type(self).__name__}** was blocked by AutoMod (Guild {guild_id})"
+                    f"View **{view_name}** ({view_module}) was blocked by AutoMod "
+                    f"(Guild {guild_id})"
                 )
                 return
 
@@ -149,7 +153,7 @@ class View(discord.ui.View):
         webhook_sent = await _send_error_webhook(interaction, description)
 
         log.exception(
-            f"Error in View **{type(item.view).__name__}** ```{error}```",
+            f"Error in View **{view_name}** ({view_module}) ```{error}```",
             exc_info=error,
             extra={"webhook_sent": webhook_sent},
         )
@@ -200,7 +204,7 @@ class Modal(discord.ui.Modal):
         webhook_sent = await _send_error_webhook(interaction, description)
 
         log.exception(
-            f"Error in Modal **{type(self).__name__}**",
+            f"Error in Modal **{type(self).__name__}** ({type(self).__module__})",
             exc_info=error,
             extra={"webhook_sent": webhook_sent},
         )

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -131,11 +131,16 @@ class View(discord.ui.View):
 
         Executes all registered error handlers with the ``@ezcord.event`` decorator.
         """
+        if not PYCORD:
+            error, item, interaction = item, interaction, error
+
         if type(error) is ErrorMessageSent:
             return
 
-        if not PYCORD:
-            error, item, interaction = item, interaction, error
+        if isinstance(error, discord.HTTPException):
+            if error.code == 200000:
+                log.warning(f"View **{type(self).__name__}** was blocked by AutoMod")
+                return
 
         description = get_error_text(interaction, error, item)
         webhook_sent = await _send_error_webhook(interaction, description)
@@ -182,11 +187,11 @@ class Modal(discord.ui.Modal):
 
         Executes all registered error handlers with the ``@ezcord.event`` decorator.
         """
-        if type(error) is ErrorMessageSent:
-            return
-
         if not PYCORD:
             error, interaction = interaction, error
+
+        if type(error) is ErrorMessageSent:
+            return
 
         description = get_error_text(interaction, error, self)
         webhook_sent = await _send_error_webhook(interaction, description)

--- a/ezcord/internal/embed_templates.py
+++ b/ezcord/internal/embed_templates.py
@@ -81,7 +81,11 @@ def get_error_text(
     else:
         location = f"- **Command:** /{ctx.command.qualified_name}"
 
-    guild_txt = f"\n- **Guild:** {ctx.guild.name} - `{ctx.guild.id}`" if ctx.guild else ""
+    guild_txt = (
+        f"\n- **Guild:** {ctx.guild.name or 'Unknown (User App)'} - `{ctx.guild.id}`"
+        if ctx.guild
+        else ""
+    )
     user_txt = f"\n- **User:** {ctx.user} - `{ctx.user.id}`" if ctx.user else ""
 
     description = location + guild_txt + user_txt + format_error(error)


### PR DESCRIPTION
When the bot is added to a user account, Discord AutoMod may block messages in certain situations. Slash commands are sent ephemeral if AutoMod blocks them, but editing messages can cause a `HTTPException`, because they can be seen by all users and can't be made ephemeral. AutoMod for bots depends on the permissions of the executing user. ([Reference](https://support.discord.com/hc/de/articles/4421269296535-AutoMod-FAQ#h_01GV3GRDBMVE8GDA7Q3JQSBRC5))

This PR prevents this error and sends a log message instead. This prevents spam when error webhooks are enabled. The behavior is implemented for slash commands and views, but the user will only be notified that the error occurred when using slash commands. This seems to be a Discord limitation.

Furthermore, the guild name was improved for error webhooks in case the bot is added to an account instead of a server.