### PR TITLE
fix(i18n): allow `get_locale` use without initializing i18n class

### DIFF
--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 __all__ = ("t", "TEmbed", "I18N")
 
 
-def t(obj: LOCALE_OBJECT, key: str, count: int | None = None, **variables):
+def t(obj: LOCALE_OBJECT | str, key: str, count: int | None = None, **variables):
     """Get the localized string for the given key and insert all variables.
 
     Parameters
@@ -197,7 +197,7 @@ def _localize_send(send_func):
         content=None,
         *,
         count: int | None = None,
-        use_locale: LOCALE_OBJECT | None = None,
+        use_locale: LOCALE_OBJECT | str | None = None,
         **kwargs,
     ):
         """Wrapper to localize the content and the embed of a message.
@@ -241,7 +241,7 @@ def _localize_edit(edit_func):
         message_id: int | None = None,
         *,
         count: int | None = None,
-        use_locale: LOCALE_OBJECT | None = None,
+        use_locale: LOCALE_OBJECT | str | None = None,
         **kwargs,
     ):
         """The message_id is only needed for followup.edit_message, because it's a positional

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -530,7 +530,7 @@ class I18N:
         return locale  # I18N class is not in use
 
     @staticmethod
-    def get_clean_locale(obj: LOCALE_OBJECT):
+    def get_clean_locale(obj: LOCALE_OBJECT | str) -> str:
         """Get the clean locale from the given object. This is the locale without the region,
         e.g. ``en`` instead of ``en-US``.
 

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -455,6 +455,8 @@ class I18N:
     def get_locale(obj):
         """Get the locale from the given object. By default, this is the guild's locale.
 
+        This method can be called even if the I18N class has not been initialized.
+
         Parameters
         ----------
         obj:
@@ -511,7 +513,7 @@ class I18N:
                 user_id = interaction.user.id
 
         # check custom language settings
-        if I18N._custom_language_settings:
+        if hasattr(I18N, "_custom_language_settings") and I18N._custom_language_settings:
             if guild_id:
                 custom_locale = I18N._custom_language_settings(guild_id)
                 locale = custom_locale or locale

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -64,3 +64,16 @@ async def test_db():
 
     if db_file.name:
         os.remove(db_file.name)
+
+
+def test_i18n():
+    class InvalidType:
+        pass
+
+    invalid_type = InvalidType()
+
+    assert ezcord.I18N.get_locale("en") == "en"
+    assert ezcord.I18N.get_locale("en-US") == "en-US"
+    assert ezcord.I18N.get_locale(invalid_type) is None
+
+    assert ezcord.I18N.get_clean_locale("en-US") == "en"

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -66,6 +66,7 @@ async def test_db():
         os.remove(db_file.name)
 
 
+@pytest.mark.dc
 def test_i18n():
     class InvalidType:
         pass

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -73,8 +73,9 @@ def test_i18n():
 
     invalid_type = InvalidType()
 
-    assert ezcord.I18N.get_locale("en") == "en"
-    assert ezcord.I18N.get_locale("en-US") == "en-US"
-    assert ezcord.I18N.get_locale(invalid_type) is None
+    if discord.__name__ == "pycord":  # Only Pycord is supported by i18n
+        assert ezcord.I18N.get_locale("en") == "en"
+        assert ezcord.I18N.get_locale("en-US") == "en-US"
+        assert ezcord.I18N.get_locale(invalid_type) is None
 
-    assert ezcord.I18N.get_clean_locale("en-US") == "en"
+        assert ezcord.I18N.get_clean_locale("en-US") == "en"


### PR DESCRIPTION
This causes the help command to fail if the I18N class is not used.. Some unit tests have been added to prevent this error in the future.