### PR TITLE
fix(ci): update nextcord versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,6 +39,7 @@ jobs:
           pytest
 
       - name: Test Nextcord
+        if: ${{ matrix.python-version == '3.12' || matrix.python-version == '3.13' }}
         run: |
           pip uninstall -y discord.py
           pip install git+https://github.com/nextcord/nextcord


### PR DESCRIPTION
Nextcord decided to require Python 3.12 or above, so the tests need to be adjusted.