### PR TITLE
docs(i18n): simplify localization docs

### DIFF
--- a/docs/examples/localization.rst
+++ b/docs/examples/localization.rst
@@ -4,10 +4,6 @@ You can localize commands and strings with EzCord.
 More information can be found in the :doc:`Localization Documentation </ezcord/i18n>`.
 This is currently only available for Pycord.
 
-- You can localize **commands** by passing a dictionary of all commands and groups to
-  :meth:`~ezcord.bot.Bot.localize_commands`
-- Other strings can be localized with the :class:`~ezcord.i18n.I18N` class
-
 .. warning::
    The following cases can't get the current locale automatically. You can use the ``use_locale``
    parameter to pass an object to extract the locale automatically.
@@ -18,6 +14,9 @@ This is currently only available for Pycord.
 
 Localize Commands
 -----------------
+You can localize **commands** by passing a dictionary of all commands and groups to
+:meth:`~ezcord.bot.Bot.localize_commands`.
+
 In this example, the commands are stored in ``commands.yaml``. Create a key for every command
 and group that you want to localize. The key is the name of the command or group.
 
@@ -31,23 +30,10 @@ and group that you want to localize. The key is the name of the command or group
 
 Localize Strings
 ----------------
-Create a language file (in this case ``en.yaml``) with the following structure:
+Strings can be localized by calling :class:`~ezcord.i18n.I18N` like in the example above.
+Create a language file (in this case ``en.yaml``) and define all strings that you want to localize.
 
-- Create a key for every file name
-- Inside the file name keys, you can create a key for every method name where you need to localize strings.
-  You can use the class name as well, that's useful for Views or Modals.
-- Now you can create a key-value pair for every string that you want to localize.
-
-Variables can be defined in the language file with curly braces.
-
-.. note::
-   The following **variable types** are available. You can find examples for all types below.
-
-   - **General:** Can be used anywhere in the language file and in the code
-   - **General, but inside a file name key:** Can be used within this file name key by placing a dot before the variable
-   - **Method specific:** These variables are specified in the code and will be replaced with the given value
-
-If general values are used within the language file, they are replaced with their value when the language file is loaded.
+Variables can be defined with curly braces, as shown in the example below.
 
 .. literalinclude:: ../../examples/localization/en.yaml
    :language: yaml
@@ -55,16 +41,8 @@ If general values are used within the language file, they are replaced with thei
 
 Usage Example
 -------------
-The language file keys can be used in multiple ways.
-
-- You can use the :meth:`~ezcord.i18n.t` function to get a localized string
-- You can use the :class:`~ezcord.i18n.TEmbed` class if you want to define the embed in the language file
-- You can simply use the language file keys as message content
-- You can even use language file keys directly in embeds, views and modals. Just make sure that
-  the key is in the language file matches the current method or class name.
-
-Variables can be passed directly to all send/edit methods like ``ctx.respond`` like in the example below.
-You can also pass variables to :meth:`~ezcord.i18n.t` or :class:`~ezcord.i18n.TEmbed`.
+The language file keys can be used almost everywhere throughout the Discord bot.
+You can see some examples below.
 
 .. literalinclude:: ../../examples/localization/example_cog.py
    :language: python

--- a/docs/examples/localization.rst
+++ b/docs/examples/localization.rst
@@ -24,7 +24,7 @@ and group that you want to localize. The key is the name of the command or group
    :language: yaml
    :caption: commands.yaml
 
-.. literalinclude:: ../../examples/localization/localization.py
+.. literalinclude:: ../../examples/localization/main.py
    :language: python
    :caption: main.py
 

--- a/examples/localization/commands.yaml
+++ b/examples/localization/commands.yaml
@@ -20,9 +20,9 @@ de:
         description: Der User, den du begrüßen möchtest.
 
   example_group:
-      group_greet:
-        name: gruppen_begrüßung
-        description: Begrüßung mit einer SlashCommandGroup
+    group_greet:
+      name: gruppen_begrüßung
+      description: Begrüßung mit einer SlashCommandGroup
 
   cogs:
     # Cogs names and descriptions can be localized as well

--- a/examples/localization/en.yaml
+++ b/examples/localization/en.yaml
@@ -1,29 +1,21 @@
 general:
-  # General values can be accessed from anywhere
-  accept: Accept
-  decline: Decline
-  cookie:
-    one: Cookie
-    many: Cookies  # Specify the plural form
+  # General values can be used anywhere in the language file with curly braces
+  # and will be replaced when the language file is loaded.
+  COOKIE: Cookie
 
-example_cog:
-  general:
-    example: example
-
+example:
   command1:
     welcome:
-      # Use lists to select a random message from the list
+      # Use lists to select a random message from the list.
+      # The user variable can be set in the Discord bot code.
       - Hey {user}
       - Hi {user}
 
-    embed1:
-      # Use general variables (global or from the current cog)
-      # In comparison to dynamic variables like {user},
-      #   general variables are inserted when the language file is loaded
-      title: "{accept} the cookie?"
-      description: This is an {.example} text!
+    welcome_cookie:
+      one: This greeting comes with a {COOKIE}.
+      many: These greetings come with many {COOKIE}s.  # Specify plural form
 
-# You can also localize the embed for the Ezcord help command
+# You can also localize the embed for the Ezcord help command.
 help:
   embed:
     title: Localized Help Command

--- a/examples/localization/example_cog.py
+++ b/examples/localization/example_cog.py
@@ -10,8 +10,8 @@ class ExampleCog(ezcord.Cog):
 
     @slash_command()
     async def command1(self, ctx: ezcord.EzContext):
-        embed = ezcord.TEmbed("embed1", color=discord.Color.blurple())
-        await ctx.respond("welcome", embed=embed, user=ctx.user.mention)
+        embed = ezcord.TEmbed("command1.embed1", color=discord.Color.blurple())
+        await ctx.respond("command1.welcome", embed=embed, user=ctx.user.mention)
 
 
 def setup(bot):

--- a/examples/localization/example_cog.py
+++ b/examples/localization/example_cog.py
@@ -9,9 +9,28 @@ class ExampleCog(ezcord.Cog):
         self.bot = bot
 
     @slash_command()
-    async def command1(self, ctx: ezcord.EzContext):
-        embed = ezcord.TEmbed("command1.embed1", color=discord.Color.blurple())
-        await ctx.respond("command1.welcome", embed=embed, user=ctx.user.mention)
+    async def example_cmd(self, ctx: ezcord.EzContext):
+        # Keys from the language file will be auto-translated.
+        await ctx.respond("example.command1.welcome", user=ctx.user.mention)
+
+        # You can use multiple keys and other values in the same string.
+        await ctx.respond("🍪 {example.command1.welcome}", user=ctx.user.mention)
+
+        # Strings can also be loaded directly.
+        text = ctx.t("example.command1.welcome", user=ctx.user.mention)
+        await ctx.respond(text)
+
+        # If ctx is not available, you can use other types to determine the language.
+        text = ezcord.t(ctx.interaction, "example.command1.welcome", user=ctx.user.mention)
+        await ctx.respond(text)
+
+        # The count variable is used for pluralization.
+        await ctx.respond("🍪 {example.command1.welcome_cookie}", count=1)
+
+        # Keys can be used in other places as well.
+        embed = discord.Embed(title="example.command1.welcome")
+        view = discord.ui.View(discord.ui.Button(label="example.command1.welcome"))
+        await ctx.respond(embed=embed, view=view)
 
 
 def setup(bot):

--- a/examples/localization/main.py
+++ b/examples/localization/main.py
@@ -2,17 +2,19 @@ import yaml
 
 import ezcord
 
-with open("commands.yaml", encoding="utf-8") as file:
-    localizations = yaml.safe_load(file)
-
 with open("en.yaml", encoding="utf-8") as file:
     en = yaml.safe_load(file)
 
 string_locals = {"en": en}
 ezcord.i18n.I18N(string_locals)
 
+
+with open("commands.yaml", encoding="utf-8") as file:
+    cmd_locales = yaml.safe_load(file)
+
+
 if __name__ == "__main__":
     bot = ezcord.Bot()
     bot.load_cogs()
-    bot.localize_commands(localizations)  # Must be called after all commands and cogs are loaded
+    bot.localize_commands(cmd_locales)  # Must be called after all commands and cogs are loaded
     bot.run()

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -328,6 +328,8 @@ class I18N:
     ignore_discord_ids:
         Whether to not localize numbers that could be a Discord ID. Default to  ``True``.
         This only has an effect if ``localize_numbers`` is set to ``True``.
+    do_not_localize:
+        If a key starts with this string, it will not be localized. Defaults to ``".."``.
     exclude_methods:
         Method names to exclude from the search of keys in the language file.
     disable_translations:
@@ -349,6 +351,7 @@ class I18N:
     prefer_user_locale: bool = False
     localize_numbers: bool
     ignore_discord_ids: bool
+    do_not_localize: str = ".."
     exclude_methods: list[str] | None
 
     _general_values: dict = {}  # general values for the current localization
@@ -368,6 +371,7 @@ class I18N:
         prefer_user_locale: bool = False,
         localize_numbers: bool = True,
         ignore_discord_ids: bool = True,
+        do_not_localize: str = "..",
         exclude_methods: list[str] | None = None,
         disable_translations: (
             list[
@@ -410,6 +414,7 @@ class I18N:
         if not exclude_methods:
             exclude_methods = []
         I18N.exclude_methods = exclude_methods
+        I18N.do_not_localize = do_not_localize
         I18N._custom_language_settings = language_settings
 
         if not disable_translations:
@@ -593,6 +598,9 @@ class I18N:
         key: str, locale: str, count: int | None, called_class: str | None, add_locations: tuple
     ) -> str:
         """Looks for the specified key in different locations of the language file."""
+
+        if key.startswith(I18N.do_not_localize):
+            return key.replace(I18N.do_not_localize, "", 1)
 
         file_name, method_name, class_name = I18N.get_location()
 


### PR DESCRIPTION
### Simplified i18n docs
This PR simplifies localization docs, adds more examples and encourages users to use the dot notation instead of the old syntax.

### `do_not_localize` parameter
An option has been added to disable translations for specific keys. This is useful for user-entered values.