### PR TITLE
fix(help): prevent error when using `/help` with prefix commands

### DIFF
--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -654,7 +654,7 @@ class Bot(_main_bot):  # type: ignore
             The description format of each category.
         permission_check:
             Whether to hide commands if a user does not have sufficient permissions to execute them.
-            Defaults to ``True``.
+            Defaults to ``False``.
         **kwargs:
             Additional variables to use in the help command. This can either be a string value or
             a callable that returns a string value.

--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -605,7 +605,8 @@ class Bot(_main_bot):  # type: ignore
         permission_check: bool = False,
         **kwargs: Callable | str,
     ):
-        """Add a help command that uses a select menu to group commands by cogs.
+        """Add a help command that uses a select menu to group commands by cogs. Note that this
+        will only include application commands.
 
         If you use :class:`Cog`, you can pass in emojis to use for the select menu.
 
@@ -652,7 +653,8 @@ class Bot(_main_bot):  # type: ignore
         description_format:
             The description format of each category.
         permission_check:
-            Whether to check for permissions before showing a command. Defaults to ``True``.
+            Whether to hide commands if a user does not have sufficient permissions to execute them.
+            Defaults to ``True``.
         **kwargs:
             Additional variables to use in the help command. This can either be a string value or
             a callable that returns a string value.

--- a/ezcord/cogs/help.py
+++ b/ezcord/cogs/help.py
@@ -187,14 +187,12 @@ class Help(Cog, hidden=True):
                 cog_cmds = [
                     cmd
                     for cmd in cog.walk_commands()
-                    if type(cmd)
+                    if isinstance(cmd, discord.ApplicationCommand)
+                    and type(cmd)
                     not in [
                         discord.MessageCommand,
                         discord.UserCommand,
                         discord.SlashCommandGroup,
-                        discord.ext.bridge.BridgeExtCommand,
-                        discord.ext.bridge.BridgeExtGroup,
-                        discord.ext.bridge.BridgeSlashGroup,
                     ]
                 ]
             else:


### PR DESCRIPTION
In Pycord, `cog.walk_commands()` returns all types of commands. The Ezcord help command only supports commands of type `ApplicationCommand`, so this PR excludes other command types.