### PR TITLE
chore: drop python 3.9, add python 3.14

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
           pytest
 
       - name: Test Nextcord
-        if: ${{ matrix.python-version == '3.12' || matrix.python-version == '3.13' }}
+        if: ${{ matrix.python-version == '3.12' || matrix.python-version == '3.13' || matrix.python-version == '3.14'}}
         run: |
           pip uninstall -y discord.py
           pip install git+https://github.com/nextcord/nextcord

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Test Pycord
         run: |
-          pip install py-cord
+          pip install git+https://github.com/Pycord-Development/pycord
           pytest
 
       - name: Test Discord.py

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v3.21.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/DanielNoord/pydocstringformatter
     rev: v0.7.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         args: [--safe, --line-length=100]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: isort
         args: ["--profile", "black"]
@@ -38,7 +38,7 @@ repos:
         args: [--disable-error-code=name-defined, --disable-error-code=import]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.0
     hooks:
       - id: pyupgrade
         args: [--py39-plus]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and [Pycord](https://github.com/Pycord-Development/pycord) with some utility fun
 - **Blacklist** - Block users from using your bot
 
 ## Installing
-Python 3.9 or higher is required.
+Python 3.10 or higher is required.
 ```
 pip install ezcord
 ```

--- a/docs/pages/getting_started.rst
+++ b/docs/pages/getting_started.rst
@@ -4,7 +4,7 @@ This page shows how to quickly get started with **EzCord**.
 
 Installing
 -----------
-Python 3.9 or higher is required.
+Python 3.10 or higher is required.
 ::
 
     pip install ezcord

--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -6,7 +6,8 @@ import os
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 
 import aiohttp
 from dotenv import load_dotenv

--- a/ezcord/bot.py
+++ b/ezcord/bot.py
@@ -4,10 +4,10 @@ import asyncio
 import logging
 import os
 import traceback
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from collections.abc import Callable
 
 import aiohttp
 from dotenv import load_dotenv

--- a/ezcord/components.py
+++ b/ezcord/components.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
-from typing import Callable
+from collections.abc import Callable
 
 import aiohttp
 

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -5,7 +5,8 @@ import random
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Literal, Union
+from typing import TYPE_CHECKING, Literal, Union
+from collections.abc import Callable
 
 from .internal.dc import PYCORD, discord
 from .logs import log

--- a/ezcord/i18n.py
+++ b/ezcord/i18n.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import inspect
 import random
 import re
+from collections.abc import Callable
 from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Union
-from collections.abc import Callable
 
 from .internal.dc import PYCORD, discord
 from .logs import log

--- a/ezcord/internal/config.py
+++ b/ezcord/internal/config.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Literal
+from typing import Literal
+from collections.abc import Callable
 
 
 @dataclass

--- a/ezcord/internal/config.py
+++ b/ezcord/internal/config.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
-from collections.abc import Callable
 
 
 @dataclass

--- a/ezcord/internal/embed_templates.py
+++ b/ezcord/internal/embed_templates.py
@@ -4,7 +4,7 @@ import inspect
 import traceback
 from copy import deepcopy
 from functools import cache
-from typing import Callable
+from collections.abc import Callable
 
 from ..internal.dc import discord
 from .config import EzConfig

--- a/ezcord/internal/embed_templates.py
+++ b/ezcord/internal/embed_templates.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import inspect
 import traceback
+from collections.abc import Callable
 from copy import deepcopy
 from functools import cache
-from collections.abc import Callable
 
 from ..internal.dc import discord
 from .config import EzConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ezcord"
 description = "An easy-to-use extension for Discord.py and Pycord"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 keywords = ["discord", "pycord", "py-cord", "discord.py"]
 authors = [
@@ -16,11 +16,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = ["dependencies", "optional-dependencies", "version"]
 


### PR DESCRIPTION
Python 3.9 reached EOL and Python 3.14 is now supported
- Reference: https://github.com/Pycord-Development/pycord/pull/2948