### PR TITLE
fix: remove old locale syntax

### DIFF
--- a/docs/examples/localization.rst
+++ b/docs/examples/localization.rst
@@ -5,12 +5,12 @@ More information can be found in the :doc:`Localization Documentation </ezcord/i
 This is currently only available for Pycord.
 
 .. warning::
-   The following cases can't get the current locale automatically. You can use the ``use_locale``
+   The following cases can't get the current locale automatically. You can use the ``locale``
    parameter to pass an object to extract the locale automatically.
 
-   - **followup.send** - Use ``interaction.respond`` instead (or pass the interaction manually using the ``use_locale`` argument
-   - **followup.edit_message** - Pass the interaction manually using the ``use_locale`` argument
-   - **DMs** - Pass a localizable object manually using the ``use_locale`` argument
+   - **followup.send** - Use ``interaction.respond`` instead (or pass the interaction manually using the ``locale`` argument
+   - **followup.edit_message** - Pass the interaction manually using the ``locale`` argument
+   - **DMs** - Pass a localizable object manually using the ``locale`` argument
 
 Localize Commands
 -----------------

--- a/ezcord/emb.py
+++ b/ezcord/emb.py
@@ -170,7 +170,7 @@ async def _send_embed(
     else:
         if I18N.initialized:
             return await target.followup.send(
-                content=content, embed=embed, ephemeral=ephemeral, use_locale=target, **kwargs
+                content=content, embed=embed, ephemeral=ephemeral, locale=target, **kwargs
             )
         else:
             return await target.followup.send(
@@ -356,7 +356,7 @@ class EzContext(_ctx_type):  # type: ignore
         return t(self.interaction, key, count, **kwargs)
 
     def convert_time(self, seconds: int | float, relative: bool = True):
-        return convert_time(seconds, relative, use_locale=self)
+        return convert_time(seconds, relative, locale=self)
 
     def convert_dt(self, dt: datetime | timedelta, relative: bool = True):
-        return convert_dt(dt, relative, use_locale=self)
+        return convert_dt(dt, relative, locale=self)


### PR DESCRIPTION
Some internal usages of `use_locale` were not removed, they have now been replaced.